### PR TITLE
Add softcore cutoff to Coulomb force.

### DIFF
--- a/src/coldatoms/coulomb.py
+++ b/src/coldatoms/coulomb.py
@@ -5,28 +5,37 @@ class CoulombForce(object):
     _epsilon0 = 8.854e-12
     _k = 4.0 * np.pi * _epsilon0
 
+    def __init__(self):
+        self.delta = 0.0
+
     def force(self, dt, ensemble):
         positions = ensemble.x
         f = np.zeros([ensemble.num_ptcls, 3])
+
+        # We guard against the case where particles are in the same
+        # location by adding a small cut off parameter to the
+        # softcore parameter. This cut off parameter is designed so that
+        # the distance raised to the third power is still different
+        # from zero so we can savely divide.
+        ulp = np.finfo(ensemble.x.dtype).tiny
+        my_delta_squared = (self.delta * self.delta +
+                            1.0e1 * ulp **(2.0/3.0))
 
         if 'charge' in ensemble.ensemble_properties:
             q = ensemble.ensemble_properties['charge']
             kp = self._k * q * q
             for i in range(ensemble.num_ptcls):
                 for j in range(ensemble.num_ptcls):
-                    if i != j:
-                        r = positions[i] - positions[j]
-                        absr = np.linalg.norm(r)
-                        f[i] += kp * r / (absr * absr * absr)
-
+                    r = positions[i] - positions[j]
+                    absr = np.sqrt(r.dot(r) + my_delta_squared)
+                    f[i] += kp * r / (absr * absr * absr)
         elif 'charge' in ensemble.particle_properties:
             q = ensemble.particle_properties['charge']
             for i in range(ensemble.num_ptcls):
                 for j in range(ensemble.num_ptcls):
-                    if i != j:
-                        r = positions[i] - positions[j]
-                        absr = np.linalg.norm(r)
-                        f[i] += self._k * q[i] * q[j] * r / (absr * absr * absr)
+                    r = positions[i] - positions[j]
+                    absr = np.sqrt(r.dot(r) + my_delta_squared)
+                    f[i] += self._k * q[i] * q[j] * r / (absr * absr * absr)
         else:
             raise RuntimeError('Must provide a charge to compute coulomb force')
 

--- a/tests/test_coulomb.py
+++ b/tests/test_coulomb.py
@@ -43,3 +43,13 @@ class test_coulomb(object):
         assert(f[0, 0] > 0)
         assert(f[0, 1] > 0)
         assert(f[0, 2] > 0)
+
+    def test_increasing_the_softcore_radius_decreases_force(self):
+        f = self.coulomb_force.force(1.0e-1, self.ensemble)
+        self.coulomb_force.delta = 1.0
+        f_softcore = self.coulomb_force.force(1.0e-1, self.ensemble)
+        assert(np.linalg.norm(f_softcore) < np.linalg.norm(f))
+
+    def test_can_evaluate_force_for_particles_in_same_position(self):
+        self.ensemble.x[1] = np.zeros(3)
+        f = self.coulomb_force.force(1.0e-1, self.ensemble)


### PR DESCRIPTION
This allows us to set a limit to the Coulomb force which can be necessary to
make naive integrators of the particle motion stable. Without such a cutoff the
Coulomb force can become arbitrarily large leading to accuracy and stability
issues in most integrators.

We bound the softcore radius from below by an amount that is designed to work
well with finite floating point precision. This allows us to get rid of the
check for identical particles in the force computation loop.