### PR TITLE
Fix Coulomb constant.

### DIFF
--- a/src/coldatoms/coulomb.py
+++ b/src/coldatoms/coulomb.py
@@ -26,7 +26,7 @@ def _coulomb_force_ref_per_particle_charges(positions, q, dt,
 class CoulombForce(object):
 
     _epsilon0 = 8.854e-12
-    _k = 4.0 * np.pi * _epsilon0
+    _k = 1.0 / (4.0 * np.pi * _epsilon0)
 
     def __init__(self):
         self.delta = 0.0

--- a/src/coldatoms_lib/forces.c
+++ b/src/coldatoms_lib/forces.c
@@ -2,7 +2,6 @@
 #include <math.h>
 #include <assert.h>
 #include <stdio.h>
-#include <float.h>
 
 #define SQR(a) ((a) * (a))
 #define NUM_COMPONENTS 3
@@ -37,19 +36,14 @@ void coulomb_force(const double *positions, double charge, double dt,
 	double delta, double k, double *forces)
 {
 	double kij = charge * charge * dt * k;
-	const double *r0 = positions;
 	for (int i = 0; i < num_ptcls; ++i) {
-		const double *r1 = positions;
+		const double *r0 = &positions[i * NUM_COMPONENTS];
+		double *f = &forces[i * NUM_COMPONENTS];
 		for (int j = 0; j < num_ptcls; ++j) {
-			if (j == i) {
-				r1 += NUM_COMPONENTS;
-				continue;
-			}
-			coulomb_force_one_pair(r0, r1, kij, delta, forces);
-			r1 += NUM_COMPONENTS;
+			if (j == i) continue;
+			const double *r1 = &positions[j * NUM_COMPONENTS];
+			coulomb_force_one_pair(r0, r1, kij, delta, f);
 		}
-		r0 += NUM_COMPONENTS;
-		forces += NUM_COMPONENTS;
 	}
 }
 
@@ -58,21 +52,16 @@ void coulomb_force_per_particle_charge(const double *positions,
 					double delta, double k, double *forces)
 {
 	double kp = dt * k;
-	const double *r0 = positions;
 	for (int i = 0; i < num_ptcls; ++i) {
 		double ki = kp * charge[i];
-		const double *r1 = positions;
+		const double *r0 = &positions[i * NUM_COMPONENTS];
+		double *f = &forces[i * NUM_COMPONENTS];
 		for (int j = 0; j < num_ptcls; ++j) {
-			if (j == i) {
-				r1 += NUM_COMPONENTS;
-				continue;
-			}
+			if (j == i) continue;
+			const double *r1 = &positions[j * NUM_COMPONENTS];
 			double kij = ki * charge[j];
-			coulomb_force_one_pair(r0, r1, kij, delta, forces);
-			r1 += NUM_COMPONENTS;
+			coulomb_force_one_pair(r0, r1, kij, delta, f);
 		}
-		r0 += NUM_COMPONENTS;
-		forces += NUM_COMPONENTS;
 	}
 }
 

--- a/src/coldatoms_lib/forces.c
+++ b/src/coldatoms_lib/forces.c
@@ -6,6 +6,7 @@
 
 #define SQR(a) ((a) * (a))
 #define DIST_CUBED_EPSILON (1.0e1 * DBL_MIN)
+#define NUM_COMPONENTS 3
 
 
 static double distance(const double *r, double delta)
@@ -18,21 +19,33 @@ static double distance(const double *r, double delta)
 	return sqrt(dist);
 }
 
-static void coulomb_force_chunked(const double *positions, double charge,
-				  double dt,
-				  int num_ptcls, double delta, double k,
-				  double *forces);
-static void coulomb_force_cleanup(const double *positions, double charge,
-				  double dt,
-				  int num_ptcls, double delta, double k,
-				  double *forces);
-
 void coulomb_force(const double *positions, double charge, double dt,
-int num_ptcls,
-		   double delta, double k, double *forces)
+	int num_ptcls,
+	double delta, double k, double *forces)
 {
-	coulomb_force_chunked(positions, charge, dt, num_ptcls, delta, k, forces);
-	coulomb_force_cleanup(positions, charge, dt, num_ptcls, delta, k, forces);
+	double kij = charge * charge * dt * k;
+	const double *r0 = positions;
+	for (int i = 0; i < num_ptcls; ++i) {
+		const double *r1 = positions;
+		for (int j = 0; j < num_ptcls; ++j) {
+			if (j == i) {
+				r1 += NUM_COMPONENTS;
+				continue;
+			}
+			double r[NUM_COMPONENTS];
+			for (int m = 0; m < NUM_COMPONENTS; ++m) {
+				r[m] = r0[m] - r1[m];
+			}
+			double dist = distance(r, delta);
+			double dist_cubed = dist * dist * dist;
+			for (int m = 0; m < NUM_COMPONENTS; ++m) {
+				forces[m] += kij * r[m] / dist_cubed;
+			}
+			r1 += NUM_COMPONENTS;
+		}
+		r0 += NUM_COMPONENTS;
+		forces += NUM_COMPONENTS;
+	}
 }
 
 void coulomb_force_per_particle_charge(const double *positions,
@@ -46,161 +59,20 @@ void coulomb_force_per_particle_charge(const double *positions,
 		const double *r1 = positions;
 		for (int j = 0; j < num_ptcls; ++j) {
 			if (j == i) {
-				r1 += 3;
+				r1 += NUM_COMPONENTS;
 				continue;
 			}
-			double r[3];
-			for (int m = 0; m < 3; ++m) {
-				r[m] = r0[m] - r1[m];
-			}
-			double dist = distance(r, delta);
-			double dist_cubed = dist * dist * dist;
-			double kj = ki * charge[j];
-			for (int m = 0; m < 3; ++m) {
-				forces[m] += kj * r[m] / dist_cubed;
-			}
-			r1 += 3;
-		}
-		r0 += 3;
-		forces += 3;
-	}
-}
-
-static void transpose(const double *restrict x, int m, int n,
-		      double *restrict y)
-{
-	for (int i = 0; i < m; ++i) {
-		for (int j = 0; j < n; ++j) {
-			y[j * m + i] = x[i * n + j];
-		}
-	}
-}
-
-static void transpose_accumulate(const double *restrict x, int m, int n,
-	double *restrict y)
-{
-	for (int i = 0; i < m; ++i) {
-		for (int j = 0; j < n; ++j) {
-			y[j * m + i] += x[i * n + j];
-		}
-	}
-}
-
-#define CHUNK_SIZE 16
-#define NUM_COMPONENTS 3
-
-static void distance_chunked(const double *restrict r, double delta, double
-			     *restrict dist)
-{
-	for (int i = 0; i < CHUNK_SIZE; ++i) {
-		dist[i] = delta;
-	}
-	for (int j = 0; j < NUM_COMPONENTS; ++j) {
-		for (int i = 0; i < CHUNK_SIZE; ++i) {
-			dist[i] += r[j * CHUNK_SIZE + i] *
-			    r[j * CHUNK_SIZE + i];
-		}
-	}
-	for (int i = 0; i < CHUNK_SIZE; ++i) {
-		dist[i] = sqrt(dist[i]);
-	}
-}
-
-static void accumulate_force(const double *restrict x0,
-			     const double *restrict x1,
-			     double *restrict f, double k, double delta)
-{
-	for (int i = 0; i < CHUNK_SIZE; ++i) {
-		double r[NUM_COMPONENTS][CHUNK_SIZE];
-		for (int m = 0; m < NUM_COMPONENTS; ++m) {
-			for (int j = 0; j < CHUNK_SIZE; ++j) {
-				r[m][j] =
-				    x0[m * CHUNK_SIZE + i] -
-				    x1[m * CHUNK_SIZE + j];
-			}
-		}
-
-		double dist[CHUNK_SIZE];
-		distance_chunked(&r[0][0], delta, &dist[0]);
-		for (int j = 0; j < CHUNK_SIZE; ++j) {
-			dist[j] = dist[j] * dist[j] * dist[j];
-		}
-
-		for (int m = 0; m < NUM_COMPONENTS; ++m) {
-			for (int j = 0; j < CHUNK_SIZE; ++j) {
-				f[m * CHUNK_SIZE + i] += k * r[m][j] / dist[j];
-			}
-		}
-	}
-}
-
-static void coulomb_force_chunked(const double *restrict positions,
-				  double charge, double dt, int num_ptcls, double delta,
-				  double k, double *restrict forces)
-{
-	int num_chunks = num_ptcls / CHUNK_SIZE;
-
-	k *= dt * charge * charge;
-
-	for (int i = 0; i < num_chunks; ++i) {
-		double x0[NUM_COMPONENTS][CHUNK_SIZE];
-		transpose(positions + i * NUM_COMPONENTS * CHUNK_SIZE,
-			  CHUNK_SIZE, NUM_COMPONENTS, &x0[0][0]);
-		double f[NUM_COMPONENTS][CHUNK_SIZE] = { {0.0} };
-		for (int j = 0; j < num_chunks; ++j) {
-			double x1[NUM_COMPONENTS][CHUNK_SIZE];
-			transpose(positions + j * NUM_COMPONENTS * CHUNK_SIZE,
-				  CHUNK_SIZE, NUM_COMPONENTS, &x1[0][0]);
-			accumulate_force(&x0[0][0], &x1[0][0], &f[0][0], k,
-					 delta);
-		}
-		transpose_accumulate(&f[0][0], NUM_COMPONENTS, CHUNK_SIZE,
-			  forces + i * NUM_COMPONENTS * CHUNK_SIZE);
-	}
-}
-
-static void coulomb_force_cleanup(const double *restrict positions,
-				  double charge, double dt, int num_ptcls, double delta,
-				  double k, double *restrict forces)
-{
-	int num_chunks = num_ptcls / CHUNK_SIZE;
-	int n0 = num_chunks * CHUNK_SIZE;
-	k *= dt * charge * charge;
-	const double *r0 = positions;
-
-	// Right leftovers.
-	for (int i = 0; i < n0; ++i) {
-		for (int j = n0; j < num_ptcls; ++j) {
-			const double *r1 = positions + NUM_COMPONENTS * j;
 			double r[NUM_COMPONENTS];
 			for (int m = 0; m < NUM_COMPONENTS; ++m) {
 				r[m] = r0[m] - r1[m];
 			}
 			double dist = distance(r, delta);
 			double dist_cubed = dist * dist * dist;
-			if (dist_cubed < DIST_CUBED_EPSILON) continue;
+			double kij = ki * charge[j];
 			for (int m = 0; m < NUM_COMPONENTS; ++m) {
-				forces[m] += k * (r[m] / dist_cubed);
+				forces[m] += kij * r[m] / dist_cubed;
 			}
-		}
-		r0 += NUM_COMPONENTS;
-		forces += NUM_COMPONENTS;
-	}
-
-	// Bottom leftovers.
-	for (int i = n0; i < num_ptcls; ++i) {
-		for (int j = 0; j < num_ptcls; ++j) {
-			const double *r1 = positions + j * NUM_COMPONENTS;
-			double r[3];
-			for (int m = 0; m < 3; ++m) {
-				r[m] = r0[m] - r1[m];
-			}
-			double dist = distance(r, delta);
-			double dist_cubed = dist * dist * dist;
-			if (dist_cubed < DIST_CUBED_EPSILON) continue;
-			for (int m = 0; m < 3; ++m) {
-				forces[m] += k * (r[m] / dist_cubed);
-			}
+			r1 += NUM_COMPONENTS;
 		}
 		r0 += NUM_COMPONENTS;
 		forces += NUM_COMPONENTS;
@@ -218,16 +90,16 @@ void harmonic_trap_forces(const double *restrict positions,
 	double alpha = q * dt;
 
 	for (int i = 0; i < num_ptcls; ++i) {
-		double x = positions[i * 3 + 0];
-		double y = positions[i * 3 + 1];
-		double z = positions[i * 3 + 2];
-		forces[i * 3 + 0] += alpha * (
+		double x = positions[i * NUM_COMPONENTS + 0];
+		double y = positions[i * NUM_COMPONENTS + 1];
+		double z = positions[i * NUM_COMPONENTS + 2];
+		forces[i * NUM_COMPONENTS + 0] += alpha * (
 			(-kx * SQR(cphi) - ky * SQR(sphi)) * x +
 			cphi * sphi * (ky - kx) * y);
-		forces[i * 3 + 1] += alpha * (
+		forces[i * NUM_COMPONENTS + 1] += alpha * (
 			cphi * sphi * (ky - kx) * x +
 			(-kx * SQR(sphi) - ky * SQR(cphi)) * y);
-		forces[i * 3 + 2] += -alpha * kz * z;
+		forces[i * NUM_COMPONENTS + 2] += -alpha * kz * z;
 	}
 }
 
@@ -244,15 +116,15 @@ void harmonic_trap_forces_per_particle_charge(
 
 	for (int i = 0; i < num_ptcls; ++i) {
 		double alpha = q[i] * dt;
-		double x = positions[i * 3 + 0];
-		double y = positions[i * 3 + 1];
-		double z = positions[i * 3 + 2];
-		forces[i * 3 + 0] += alpha * (
+		double x = positions[i * NUM_COMPONENTS + 0];
+		double y = positions[i * NUM_COMPONENTS + 1];
+		double z = positions[i * NUM_COMPONENTS + 2];
+		forces[i * NUM_COMPONENTS + 0] += alpha * (
 			(-kx * SQR(cphi) - ky * SQR(sphi)) * x +
 			cphi * sphi * (ky - kx) * y);
-		forces[i * 3 + 1] += alpha * (
+		forces[i * NUM_COMPONENTS + 1] += alpha * (
 			cphi * sphi * (ky - kx) * x +
 			(-kx * SQR(sphi) - ky * SQR(cphi)) * y);
-		forces[i * 3 + 2] += -alpha * kz * z;
+		forces[i * NUM_COMPONENTS + 2] += -alpha * kz * z;
 	}
 }

--- a/tests/test_coulomb.py
+++ b/tests/test_coulomb.py
@@ -90,6 +90,25 @@ class test_coulomb(object):
             np.linalg.norm(self.f[0])**2 + np.linalg.norm(f_expected)**2)
         assert(np.linalg.norm(self.f[0] - f_expected) / normalization < 1.0e-9)
 
+    def test_spot_check(self):
+        self.ensemble = coldatoms.Ensemble(2)
+        self.ensemble.x[0, :] = 0.0
+        self.ensemble.x[1, 0] = 1.3
+        self.ensemble.x[1, 1] = 1.5
+        self.ensemble.x[1, 2] = 1.7
+        q = 1.3
+        self.ensemble.ensemble_properties['charge'] = q
+        dt = 1.0e-2
+        r = self.ensemble.x[0, :] - self.ensemble.x[1, :]
+        dist = np.linalg.norm(r)
+        ke = 1.0 / (4.0 * np.pi * 8.854e-12)
+        f_expected = ke * r * q * q / (dist**3)
+        f_expected *= dt
+        self.coulomb_force.force(dt, self.ensemble, self.f)
+        normalization = np.sqrt(
+            np.linalg.norm(self.f[0])**2 + np.linalg.norm(f_expected)**2)
+        assert(np.linalg.norm(self.f[0] - f_expected) / normalization < 1.0e-9)
+
     def test_compare_per_particle_charge_algs_with_reference_impl(self):
         m, n = self.ensemble.x.shape
         self.ensemble.x = np.random.rand(m, n)

--- a/tests/test_coulomb.py
+++ b/tests/test_coulomb.py
@@ -70,6 +70,26 @@ class test_coulomb(object):
         normalization = np.linalg.norm(f_ref) + np.linalg.norm(f)
         assert(np.linalg.norm(f - f_ref) < 1.0e-9 * normalization)
 
+    def test_per_particle_charge_spot_check(self):
+        self.ensemble = coldatoms.Ensemble(2)
+        self.ensemble.x[0, :] = 0.0
+        self.ensemble.x[1, 0] = 1.3
+        self.ensemble.x[1, 1] = 1.5
+        self.ensemble.x[1, 2] = 1.7
+        q = 1.3 * np.array([1.6e-19, 2.0 * 1.6e-19])
+        self.ensemble.ensemble_properties = {}
+        self.ensemble.set_particle_property('charge', q)
+        dt = 1.0e-2
+        r = self.ensemble.x[0, :] - self.ensemble.x[1, :]
+        dist = np.linalg.norm(r)
+        ke = 1.0 / (4.0 * np.pi * 8.854e-12)
+        f_expected = ke * r * q[0] * q[1] / (dist**3)
+        f_expected *= dt
+        self.coulomb_force.force(dt, self.ensemble, self.f)
+        normalization = np.sqrt(
+            np.linalg.norm(self.f[0])**2 + np.linalg.norm(f_expected)**2)
+        assert(np.linalg.norm(self.f[0] - f_expected) / normalization < 1.0e-9)
+
     def test_compare_per_particle_charge_algs_with_reference_impl(self):
         m, n = self.ensemble.x.shape
         self.ensemble.x = np.random.rand(m, n)


### PR DESCRIPTION
This leads to all kinds of breakage because now we have a large numerator and
when the r^3 in the denominator gets too small we're in deep trouble.